### PR TITLE
feat: support CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/src/claude/utils/path.test.ts
+++ b/src/claude/utils/path.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getProjectPath } from './path';
 import { join } from 'node:path';
 
@@ -6,7 +6,20 @@ vi.mock('node:os', () => ({
     homedir: vi.fn(() => '/home/user')
 }));
 
+// Store original env
+const originalEnv = process.env;
+
 describe('getProjectPath', () => {
+    beforeEach(() => {
+        // Reset process.env to a clean state
+        process.env = { ...originalEnv };
+        delete process.env.CLAUDE_CONFIG_DIR;
+    });
+
+    afterEach(() => {
+        // Restore original env
+        process.env = originalEnv;
+    });
     it('should replace slashes with hyphens in the project path', () => {
         const workingDir = '/Users/steve/projects/my-app';
         const result = getProjectPath(workingDir);
@@ -36,5 +49,41 @@ describe('getProjectPath', () => {
         const workingDir = '';
         const result = getProjectPath(workingDir);
         expect(result).toContain(join('/home/user', '.claude', 'projects'));
+    });
+
+    describe('CLAUDE_CONFIG_DIR support', () => {
+        it('should use default .claude directory when CLAUDE_CONFIG_DIR is not set', () => {
+            const workingDir = '/Users/steve/projects/my-app';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/home/user', '.claude', 'projects', '-Users-steve-projects-my-app'));
+        });
+
+        it('should use CLAUDE_CONFIG_DIR when set', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/custom/claude/config';
+            const workingDir = '/Users/steve/projects/my-app';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/custom/claude/config', 'projects', '-Users-steve-projects-my-app'));
+        });
+
+        it('should handle relative CLAUDE_CONFIG_DIR path', () => {
+            process.env.CLAUDE_CONFIG_DIR = './config/claude';
+            const workingDir = '/Users/steve/projects/my-app';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('./config/claude', 'projects', '-Users-steve-projects-my-app'));
+        });
+
+        it('should fallback to default when CLAUDE_CONFIG_DIR is empty string', () => {
+            process.env.CLAUDE_CONFIG_DIR = '';
+            const workingDir = '/Users/steve/projects/my-app';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/home/user', '.claude', 'projects', '-Users-steve-projects-my-app'));
+        });
+
+        it('should handle CLAUDE_CONFIG_DIR with trailing slash', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/custom/claude/config/';
+            const workingDir = '/Users/steve/projects/my-app';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/custom/claude/config/', 'projects', '-Users-steve-projects-my-app'));
+        });
     });
 });

--- a/src/claude/utils/path.ts
+++ b/src/claude/utils/path.ts
@@ -3,5 +3,6 @@ import { join, resolve } from "node:path";
 
 export function getProjectPath(workingDirectory: string) {
     const projectId = resolve(workingDirectory).replace(/[\\\/\.:]/g, '-');
-    return join(homedir(), '.claude', 'projects', projectId);
+    const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+    return join(claudeConfigDir, 'projects', projectId);
 }


### PR DESCRIPTION
Respect `CLAUDE_CONFIG_DIR` for session file storage instead of hardcoding `~/.claude`.
Falls back to default when not set.
Includes tests.

When `CLAUDE_CONFIG_DIR` is not respected, Happy is unable to read the project/session history, and sessions always appear empty in the app.