### PR TITLE
Removing the -d option which prevents screen lock, display turn off

### DIFF
--- a/src/utils/caffeinate.ts
+++ b/src/utils/caffeinate.ts
@@ -29,10 +29,9 @@ export function startCaffeinate(): boolean {
 
     try {
         // Spawn caffeinate with flags:
-        // -d: Prevent display from sleeping
         // -i: Prevent system from idle sleeping  
         // -m: Prevent disk from sleeping
-        caffeinateProcess = spawn('caffeinate', ['-dim'], {
+        caffeinateProcess = spawn('caffeinate', ['-im'], {
             stdio: 'ignore',
             detached: false
         })


### PR DESCRIPTION
With the -d present, the display never turns off or locks. 