### PR TITLE
Expose codex and connect commands in CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ This will:
 2. Display a QR code to connect from your mobile device
 3. Allow real-time session sharing between Claude Code and your mobile app
 
+## Commands
+
+- `happy auth` – Manage authentication
+- `happy codex` – Start Codex mode
+- `happy connect` – Store AI vendor API keys in Happy cloud
+- `happy notify` – Send a push notification to your devices
+- `happy daemon` – Manage background service
+- `happy doctor` – System diagnostics & troubleshooting
+
 ## Options
 
 - `-h, --help` - Show help

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -9,8 +9,8 @@ import { authenticateGemini } from './connect/authenticateGemini';
  * Handle connect subcommand
  * 
  * Implements connect subcommands for storing AI vendor API keys:
- * - connect openai: Store OpenAI API key in Happy cloud
- * - connect anthropic: Store Anthropic API key in Happy cloud
+ * - connect codex: Store OpenAI API key in Happy cloud
+ * - connect claude: Store Anthropic API key in Happy cloud
  * - connect gemini: Store Gemini API key in Happy cloud
  * - connect help: Show help for connect command
  */
@@ -45,7 +45,7 @@ ${chalk.bold('happy connect')} - Connect AI vendor API keys to Happy cloud
 
 ${chalk.bold('Usage:')}
   happy connect codex        Store your Codex API key in Happy cloud
-  happy connect anthropic    Store your Anthropic API key in Happy cloud
+  happy connect claude       Store your Anthropic API key in Happy cloud
   happy connect gemini       Store your Gemini API key in Happy cloud
   happy connect help         Show this help message
 
@@ -56,7 +56,7 @@ ${chalk.bold('Description:')}
 
 ${chalk.bold('Examples:')}
   happy connect codex
-  happy connect anthropic
+  happy connect claude
   happy connect gemini
 
 ${chalk.bold('Notes:')} 

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,6 +285,9 @@ ${chalk.bold('happy')} - Claude Code On the Go
 ${chalk.bold('Usage:')}
   happy [options]         Start Claude with mobile control
   happy auth              Manage authentication
+  happy codex             Start Codex mode
+  happy connect           Connect AI vendor API keys
+  happy notify            Send push notification
   happy daemon            Manage background service that allows
                             to spawn new sessions away from your computer
   happy doctor            System diagnostics & troubleshooting
@@ -413,7 +416,7 @@ ${chalk.bold('Examples:')}
   // Load credentials
   let credentials = await readCredentials()
   if (!credentials) {
-    console.error(chalk.red('Error: Not authenticated. Please run "happy --auth" first.'))
+    console.error(chalk.red('Error: Not authenticated. Please run "happy auth login" first.'))
     process.exit(1)
   }
 


### PR DESCRIPTION
## Summary
- Document `codex`, `connect`, and `notify` in the main `happy --help` output
- Fix `connect` subcommand names and usage to match `claude`/`codex`/`gemini`
- Clarify notify authentication message and list available commands in README

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68bfe02508ac8332ba501054f8e78503