### PR TITLE
fix: pass environment variables to codex MCP process

### DIFF
--- a/src/codex/codexMcpClient.ts
+++ b/src/codex/codexMcpClient.ts
@@ -57,7 +57,12 @@ export class CodexMcpClient {
 
         this.transport = new StdioClientTransport({
             command: 'codex',
-            args: ['mcp']
+            args: ['mcp'],
+            env: Object.keys(process.env).reduce((acc, key) => {
+                const value = process.env[key];
+                if (typeof value === 'string') acc[key] = value;
+                return acc;
+            }, {} as Record<string, string>)
         });
 
         // Register request handlers for Codex permission methods


### PR DESCRIPTION
# Fix: Pass environment variables to codex MCP process

## Problem
When running `happy codex` with custom environment variables configured in `~/.codex/config.toml`, the command fails with "Missing environment variable: MY_ENV_KEY" error.

**Steps to Reproduce:**
1. Add `env_key = "MY_ENV_KEY"` to `~/.codex/config.toml`
2. Set environment variable: `export MY_ENV_KEY="some_value"`
3. Run `happy codex`
4. Error: "Missing environment variable: MY_ENV_KEY"

## Solution
The `StdioClientTransport` constructor was not passing environment variables to the codex subprocess. Added proper environment variable inheritance in `src/codex/codexMcpClient.ts`.

**Code Changes:**
```typescript
// Before
this.transport = new StdioClientTransport({
    command: 'codex',
    args: ['mcp']
});

// After  
this.transport = new StdioClientTransport({
    command: 'codex',
    args: ['mcp'],
    env: Object.keys(process.env).reduce((acc, key) => {
        const value = process.env[key];
        if (typeof value === 'string') acc[key] = value;
        return acc;
    }, {} as Record<string, string>)
});
```

## Testing
- ✅ `happy codex` now starts without environment variable errors
- ✅ Custom environment variables properly inherited by codex process
- ✅ No breaking changes

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #[ISSUE_NUMBER] (if applicable)
