### PR TITLE
feat: add HAPPY_DISABLE_CAFFEINATE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ This will:
 - `--claude-env KEY=VALUE` - Set environment variable for Claude Code
 - `--claude-arg ARG` - Pass additional argument to Claude CLI
 
+## Environment Variables
+
+- `HAPPY_SERVER_URL` - Custom server URL (default: https://api.cluster-fluster.com)
+- `HAPPY_WEBAPP_URL` - Custom web app URL (default: https://app.happy.engineering)
+- `HAPPY_HOME_DIR` - Custom home directory for Happy data (default: ~/.happy)
+- `HAPPY_DISABLE_CAFFEINATE` - Disable macOS sleep prevention (set to `true`, `1`, or `yes`)
+- `HAPPY_EXPERIMENTAL` - Enable experimental features (set to `true`, `1`, or `yes`)
+
 ## Requirements
 
 - Node.js >= 20.0.0

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -25,6 +25,7 @@ class Configuration {
   public readonly currentCliVersion: string
 
   public readonly isExperimentalEnabled: boolean
+  public readonly disableCaffeinate: boolean
 
   constructor() {
     // Server configuration - priority: parameter > environment > default
@@ -51,6 +52,7 @@ class Configuration {
     this.daemonLockFile = join(this.happyHomeDir, 'daemon.state.json.lock')
 
     this.isExperimentalEnabled = ['true', '1', 'yes'].includes(process.env.HAPPY_EXPERIMENTAL?.toLowerCase() || '');
+    this.disableCaffeinate = ['true', '1', 'yes'].includes(process.env.HAPPY_DISABLE_CAFFEINATE?.toLowerCase() || '');
 
     this.currentCliVersion = packageJson.version
 

--- a/src/utils/caffeinate.ts
+++ b/src/utils/caffeinate.ts
@@ -5,6 +5,7 @@
 
 import { spawn, ChildProcess } from 'child_process'
 import { logger } from '@/ui/logger'
+import { configuration } from '@/configuration'
 
 let caffeinateProcess: ChildProcess | null = null
 
@@ -15,6 +16,12 @@ let caffeinateProcess: ChildProcess | null = null
  * @returns true if caffeinate was started, false otherwise
  */
 export function startCaffeinate(): boolean {
+    // Check if caffeinate is disabled via configuration
+    if (configuration.disableCaffeinate) {
+        logger.debug('[caffeinate] Caffeinate disabled via HAPPY_DISABLE_CAFFEINATE environment variable')
+        return false
+    }
+
     // Only run on macOS
     if (process.platform !== 'darwin') {
         logger.debug('[caffeinate] Not on macOS, skipping caffeinate')


### PR DESCRIPTION
Adds a new environment variable to disable the automatic caffeinate process on macOS. This allows users who manage their own sleep prevention (or prefer to allow sleep) to disable the built-in behavior.

Usage: HAPPY_DISABLE_CAFFEINATE=1 happy

Accepts values: true, 1, yes (case-insensitive)

Changes:
- Added disableCaffeinate configuration option to Configuration class
- Modified startCaffeinate() to check configuration before starting
- Updated README with new environment variable documentation