### PR TITLE
fix: resolve MCP bridge startup failure on Windows

### DIFF
--- a/src/codex/runCodex.ts
+++ b/src/codex/runCodex.ts
@@ -538,8 +538,8 @@ export async function runCodex(opts: {
     const bridgeCommand = join(projectPath(), 'bin', 'happy-mcp.mjs');
     const mcpServers = {
         happy: {
-            command: bridgeCommand,
-            args: ['--url', happyServer.url]
+            command: process.execPath,
+            args: [bridgeCommand, '--url', happyServer.url]
         }
     } as const;
     let first = true;


### PR DESCRIPTION
## Summary
  - fix "%1 is not a valid Win32 application" (os error 193) errors  on Windows when the happy MCP bridge starts
  - launch the bridge through `process.execPath` so Node runs the  `.mjs` script consistently on every platform

## Linked Issues
https://github.com/slopus/happy/issues/139