### PR TITLE
bump claude-code version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "postinstall": "node scripts/unpack-tools.cjs"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "2.0.14",
+    "@anthropic-ai/claude-code": "2.0.24",
     "@anthropic-ai/sdk": "0.65.0",
     "@modelcontextprotocol/sdk": "^1.15.1",
     "@stablelib/base64": "^2.0.1",


### PR DESCRIPTION
Got this error when using happy, bumped version and linked locally then works.
```
Error: 400
  {"type":"error","error":{"type":"invalid_request_error","message":"Please
  upgrade using: npm update -g @anthropic-ai/claude-code"}}
```

We might need a new version 🤔