### PR TITLE
fix: adapt to claude-code package split (2.0.25 + agent-sdk)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "postinstall": "node scripts/unpack-tools.cjs"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "2.0.14",
+    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "@anthropic-ai/claude-code": "2.0.25",
     "@anthropic-ai/sdk": "0.65.0",
     "@modelcontextprotocol/sdk": "^1.15.1",
     "@stablelib/base64": "^2.0.1",

--- a/src/utils/MessageQueue.ts
+++ b/src/utils/MessageQueue.ts
@@ -1,4 +1,4 @@
-import { SDKMessage, SDKUserMessage } from "@anthropic-ai/claude-code";
+import { SDKMessage, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "@/ui/logger";
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,22 @@
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^5.0.0"
 
-"@anthropic-ai/claude-code@2.0.14":
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-code/-/claude-code-2.0.14.tgz#c4b9d06bb34c4478fd835afb5f58ea384a54db06"
-  integrity sha512-Q4A4Jo7WZ4aMUIu8CUIIo2Jt66kl2vrEjRg/kYzX6syuK0DiV3WhdMZceSvLAU0BFpX1L8aERhRWxLWDxX3fYg==
+"@anthropic-ai/claude-agent-sdk@^0.1.0":
+  version "0.1.25"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.25.tgz#547d3d833aeb5a42468286f9fadbfb690e27a4ea"
+  integrity sha512-qwuydYaA3uamz4ivDzYXfL2PBjGwc0+beeIyo3nvtZQOtFLjH7xPdBK2w3+9KnB3L6V7VooAMdTXPpQyxCwcOg==
+  optionalDependencies:
+    "@img/sharp-darwin-arm64" "^0.33.5"
+    "@img/sharp-darwin-x64" "^0.33.5"
+    "@img/sharp-linux-arm" "^0.33.5"
+    "@img/sharp-linux-arm64" "^0.33.5"
+    "@img/sharp-linux-x64" "^0.33.5"
+    "@img/sharp-win32-x64" "^0.33.5"
+
+"@anthropic-ai/claude-code@2.0.25":
+  version "2.0.25"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/claude-code/-/claude-code-2.0.25.tgz#6713977ae7008dfbb5fb1a173d44f679c22f130e"
+  integrity sha512-5gooMB9DCLmzatQ+b2R0/pP2WxUSADcmpF77Qf3fIDpTf30UFreLXl2pe1exJ2kInsfiPK7PvDuJip5MDEv4CQ==
   optionalDependencies:
     "@img/sharp-darwin-arm64" "^0.33.5"
     "@img/sharp-darwin-x64" "^0.33.5"


### PR DESCRIPTION
Updates happy-cli to work with the split Claude SDK packages:
- Upgraded `@anthropic-ai/claude-code` from 2.0.14 to 2.0.25
- Added `@anthropic-ai/claude-agent-sdk` ^0.1.0 (now separate package for types)
- Updated imports accordingly

Fixes slopus/happy#450