### PR TITLE
fix: resolve codex approval response ID mismatch

### DIFF
--- a/src/codex/__tests__/permissionApprovalFlow.test.ts
+++ b/src/codex/__tests__/permissionApprovalFlow.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CodexPermissionHandler } from '../utils/permissionHandler';
+import type { ApiSessionClient } from '@/api/apiSession';
+
+// Mock ApiSessionClient
+const createMockSession = (): ApiSessionClient => {
+    const rpcHandlers = new Map<string, (data: any) => Promise<any>>();
+    
+    return {
+        sessionId: 'test-session-id',
+        updateAgentState: vi.fn((updater: any) => {
+            const currentState = { requests: {}, completedRequests: {} };
+            const newState = updater(currentState);
+            return newState;
+        }),
+        rpcHandlerManager: {
+            registerHandler: vi.fn((method: string, handler: (data: any) => Promise<any>) => {
+                rpcHandlers.set(method, handler);
+            }),
+            call: vi.fn(),
+        },
+        sendCodexMessage: vi.fn(),
+        sendSessionEvent: vi.fn(),
+        onUserMessage: vi.fn(),
+        keepAlive: vi.fn(),
+        flush: vi.fn(),
+        close: vi.fn(),
+        sendSessionDeath: vi.fn(),
+    } as unknown as ApiSessionClient;
+};
+
+describe('Codex Permission Approval Flow', () => {
+    let session: ApiSessionClient;
+    let permissionHandler: CodexPermissionHandler;
+
+    beforeEach(() => {
+        session = createMockSession();
+        permissionHandler = new CodexPermissionHandler(session);
+    });
+
+    it('should register permission request with correct ID and resolve when permission response matches', async () => {
+        const toolCallId = 'test-call-id-123';
+        const toolName = 'CodexBash';
+        const input = { command: ['ls'], cwd: '/tmp' };
+
+        // Register permission request
+        const permissionPromise = permissionHandler.handleToolCall(toolCallId, toolName, input);
+
+        // Simulate permission response from mobile app
+        const rpcHandler = (session.rpcHandlerManager.registerHandler as any).mock.calls[0][1];
+        
+        // Wait a bit to ensure the request is registered
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        // Send permission response with matching ID
+        await rpcHandler({
+            id: toolCallId,
+            approved: true,
+            decision: 'approved' as const
+        });
+
+        // Wait for permission to be resolved
+        const result = await permissionPromise;
+
+        expect(result.decision).toBe('approved');
+        expect(session.updateAgentState).toHaveBeenCalled();
+    });
+
+    it('should not resolve permission request when response ID does not match', async () => {
+        const toolCallId = 'test-call-id-123';
+        const wrongId = 'wrong-call-id-456';
+        const toolName = 'CodexBash';
+        const input = { command: ['ls'], cwd: '/tmp' };
+
+        // Register permission request
+        const permissionPromise = permissionHandler.handleToolCall(toolCallId, toolName, input);
+
+        // Simulate permission response from mobile app with wrong ID
+        const rpcHandler = (session.rpcHandlerManager.registerHandler as any).mock.calls[0][1];
+        
+        // Wait a bit to ensure the request is registered
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        // Send permission response with non-matching ID
+        await rpcHandler({
+            id: wrongId,
+            approved: true,
+            decision: 'approved' as const
+        });
+
+        // Permission should not be resolved (still pending)
+        // Use a timeout to verify it doesn't resolve
+        let resolved = false;
+        permissionPromise.then(() => {
+            resolved = true;
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+        
+        // The permission should still be pending since IDs don't match
+        expect(resolved).toBe(false);
+    });
+
+    it('should handle permission denial correctly', async () => {
+        const toolCallId = 'test-call-id-123';
+        const toolName = 'CodexBash';
+        const input = { command: ['rm', '-rf', '/'], cwd: '/' };
+
+        // Register permission request
+        const permissionPromise = permissionHandler.handleToolCall(toolCallId, toolName, input);
+
+        // Simulate permission response denying the request
+        const rpcHandler = (session.rpcHandlerManager.registerHandler as any).mock.calls[0][1];
+        
+        // Wait a bit to ensure the request is registered
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        // Send permission response denying
+        await rpcHandler({
+            id: toolCallId,
+            approved: false,
+            decision: 'denied' as const
+        });
+
+        // Wait for permission to be resolved
+        const result = await permissionPromise;
+
+        expect(result.decision).toBe('denied');
+    });
+
+    it('should handle multiple permission requests with different IDs', async () => {
+        const toolCallId1 = 'test-call-id-123';
+        const toolCallId2 = 'test-call-id-456';
+        const toolName = 'CodexBash';
+        const input1 = { command: ['ls'], cwd: '/tmp' };
+        const input2 = { command: ['pwd'], cwd: '/tmp' };
+
+        // Register two permission requests
+        const permissionPromise1 = permissionHandler.handleToolCall(toolCallId1, toolName, input1);
+        const permissionPromise2 = permissionHandler.handleToolCall(toolCallId2, toolName, input2);
+
+        // Simulate permission responses
+        const rpcHandler = (session.rpcHandlerManager.registerHandler as any).mock.calls[0][1];
+        
+        // Wait a bit to ensure requests are registered
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        // Send permission response for first request
+        await rpcHandler({
+            id: toolCallId1,
+            approved: true,
+            decision: 'approved' as const
+        });
+
+        // Send permission response for second request
+        await rpcHandler({
+            id: toolCallId2,
+            approved: true,
+            decision: 'approved' as const
+        });
+
+        // Both permissions should be resolved
+        const result1 = await permissionPromise1;
+        const result2 = await permissionPromise2;
+
+        expect(result1.decision).toBe('approved');
+        expect(result2.decision).toBe('approved');
+    });
+});
+

--- a/src/codex/codexMcpClient.ts
+++ b/src/codex/codexMcpClient.ts
@@ -134,9 +134,14 @@ export class CodexMcpClient {
                 }
 
                 try {
-                    // Request permission through the handler
+                    // Use codex_mcp_tool_call_id for permission request registration
+                    // to match the call_id that will be used in exec_approval_request event
+                    const actualCallId = params.codex_mcp_tool_call_id || params.codex_call_id;
+
+                    // Request permission through the handler using the actual call_id
+                    // that will match the call_id in exec_approval_request event
                     const result = await this.permissionHandler.handleToolCall(
-                        params.codex_call_id,
+                        actualCallId,
                         toolName,
                         {
                             command: params.codex_command,


### PR DESCRIPTION
## Problem

When executing commands like `ls` in Codex, approval requests are displayed on the mobile app, but selecting YES does not work. The command execution hangs waiting for approval, even though the user has approved the request.

## Root Cause

The issue was an ID mismatch between the permission request registration and the permission response handling. This likely appeared after codex-cli version updates (verified with codex-cli 0.58.0):

1. The elicitation handler in `codexMcpClient.ts` registered permission requests using `codex_call_id`
2. The `exec_approval_request` event uses `codex_mcp_tool_call_id` as its `call_id`
3. The mobile app sends permission responses using the `callId` from the `tool-call` message, which corresponds to `codex_mcp_tool_call_id`
4. The permission handler looked up requests by the response ID, but couldn't find them because they were registered with a different ID (`codex_call_id`)

## Solution

Changed the permission request registration to use `codex_mcp_tool_call_id` (with fallback to `codex_call_id` for backward compatibility) to match the ID that will be used in:
- The `exec_approval_request` event's `call_id`
- The `tool-call` message sent to the mobile app
- The permission response from the mobile app

This ensures the permission response ID matches the registered permission request ID.

## Changes

- **`src/codex/codexMcpClient.ts`**: Use `codex_mcp_tool_call_id` instead of `codex_call_id` when registering permission requests
- **`src/codex/__tests__/permissionApprovalFlow.test.ts`**: Added comprehensive tests for the permission approval flow

## Testing

### Test Results
```bash
$ yarn test src/codex/__tests__/permissionApprovalFlow.test.ts
✓ src/codex/__tests__/permissionApprovalFlow.test.ts (4 tests) 166ms
  ✓ should register permission request with correct ID and resolve when permission response matches
  ✓ should not resolve permission request when response ID does not match
  ✓ should handle permission denial correctly
  ✓ should handle multiple permission requests with different IDs
```

### Type Check
```bash
$ yarn typecheck
✓ Type check passed
```

### Manual Testing Steps
1. Start daemon: `happy daemon start`
2. Launch Codex from mobile app
3. Select a folder and start Codex session
4. Execute a command like `ls` that requires approval
5. Approve the request on mobile app
6. Verify the command executes successfully

### Real Device Testing
✅ **Verified on real device**: Approval flow (OK/NG) works correctly after this fix
- Tested approval requests with YES/NO responses
- Commands execute successfully when approved
- Commands are properly denied when rejected

**Note**: This issue likely appeared after codex-cli version updates. Verified working with codex-cli 0.58.0.

## Backward Compatibility

The fix includes a fallback to `codex_call_id` if `codex_mcp_tool_call_id` is not available, ensuring compatibility with older Codex versions or different deployment configurations.

## Test Results

All tests related to this change pass:
- ✅ `permissionApprovalFlow.test.ts` - All 4 tests pass
- ✅ Type check passes
