### PR TITLE
Add automatic preview publishing workflow

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,101 @@
+name: Publish Preview to npm
+
+on:
+  push:
+    branches:
+      - new/refactor-codex-cli-integration-32gs7i  # Your preview branch
+      - 'preview/**'  # Also match any preview/* branches
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  publish-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate preview version
+        id: version
+        run: |
+          # Get current version from package.json
+          CURRENT_VERSION=$(node -p "require('./package-next.json').version")
+
+          # Extract base version (strip any existing preview suffix)
+          BASE_VERSION=$(echo $CURRENT_VERSION | sed 's/-preview\..*//')
+
+          # Generate preview version with short commit hash
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          PREVIEW_VERSION="${BASE_VERSION}-preview.${TIMESTAMP}.${SHORT_SHA}"
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "Preview version: $PREVIEW_VERSION"
+          echo "version=$PREVIEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update package version
+        run: |
+          # Update version in package-next.json
+          node -e "const pkg = require('./package-next.json'); pkg.version = '${{ steps.version.outputs.version }}'; require('fs').writeFileSync('package-next.json', JSON.stringify(pkg, null, 2) + '\n');"
+
+      - name: Install dependencies
+        run: |
+          npm ci
+
+      - name: Build distribution
+        run: |
+          npm run build
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # Use package-next.json for publishing
+          cp package-next.json package.json
+          npm publish --tag preview --access public
+
+          echo "✅ Published happy-next@${{ steps.version.outputs.version }} to npm with 'preview' tag"
+          echo ""
+          echo "Install with: npm install -g happy-next@preview"
+          echo "Or specific version: npm install -g happy-next@${{ steps.version.outputs.version }}"
+
+      - name: Create summary
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          # 🚀 Preview Published
+
+          **Package:** \`happy-next\`
+          **Version:** \`${{ steps.version.outputs.version }}\`
+          **Tag:** \`preview\`
+
+          ## Installation
+
+          Install the latest preview:
+          \`\`\`bash
+          npm install -g happy-next@preview
+          \`\`\`
+
+          Install this specific version:
+          \`\`\`bash
+          npm install -g happy-next@${{ steps.version.outputs.version }}
+          \`\`\`
+
+          ## View on npm
+
+          https://www.npmjs.com/package/happy-next/v/${{ steps.version.outputs.version }}
+          EOF


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically publishes preview versions to npm on every push to preview branches.

## What This Does

- **Triggers**: Automatically on every push to `new/refactor-codex-cli-integration-32gs7i` and any `preview/*` branches
- **Version Format**: `<version>-preview.<timestamp>.<commit-hash>` (e.g., `0.11.3-preview.20251118001857.9b700ed`)
- **Publishing**: Publishes to npm with `@preview` tag
- **Installation**: Users can install with `npm install -g happy-next@preview`

## Benefits

✅ **No manual publishing** - Just push your changes
✅ **Unique versions** - Every commit gets a unique installable version
✅ **Easy testing** - Users can test previews immediately after push
✅ **Fast feedback** - 2-3 minutes from push to published

## Testing

Once merged, push any change to the preview branch and verify:
1. Workflow runs at https://github.com/jakenuts/happy-cli/actions
2. Package appears on npm as `happy-next@preview`
3. Can install with `npm install -g happy-next@preview`

## Related

- Fixes the manual publishing workflow issue
- Enables continuous preview releases for rapid iteration