### PR TITLE
Implement --claude-env flag to pass environment variables to Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will:
 - `-v, --version` - Show version
 - `-m, --model <model>` - Claude model to use (default: sonnet)
 - `-p, --permission-mode <mode>` - Permission mode: auto, default, or plan
-- `--claude-env KEY=VALUE` - Set environment variable for Claude Code
+- `--claude-env KEY=VALUE` - Set environment variable for Claude Code (e.g., for [claude-code-router](https://github.com/musistudio/claude-code-router))
 - `--claude-arg ARG` - Pass additional argument to Claude CLI
 
 ## Environment Variables

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,19 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
         unknownArgs.push('--dangerously-skip-permissions')
       } else if (arg === '--started-by') {
         options.startedBy = args[++i] as 'daemon' | 'terminal'
+      } else if (arg === '--claude-env') {
+        // Parse KEY=VALUE environment variable to pass to Claude
+        const envArg = args[++i]
+        if (envArg && envArg.includes('=')) {
+          const eqIndex = envArg.indexOf('=')
+          const key = envArg.substring(0, eqIndex)
+          const value = envArg.substring(eqIndex + 1)
+          options.claudeEnvVars = options.claudeEnvVars || {}
+          options.claudeEnvVars[key] = value
+        } else {
+          console.error(chalk.red(`Invalid --claude-env format: ${envArg}. Expected KEY=VALUE`))
+          process.exit(1)
+        }
       } else {
         // Pass unknown arguments through to claude
         unknownArgs.push(arg)
@@ -303,8 +316,10 @@ ${chalk.bold('Usage:')}
 
 ${chalk.bold('Examples:')}
   happy                    Start session
-  happy --yolo             Start with bypassing permissions 
+  happy --yolo             Start with bypassing permissions
                             happy sugar for --dangerously-skip-permissions
+  happy --claude-env ANTHROPIC_BASE_URL=http://127.0.0.1:3456
+                           Use a custom API endpoint (e.g., claude-code-router)
   happy auth login --force Authenticate
   happy doctor             Run diagnostics
 


### PR DESCRIPTION
Enables  passing Claude environment variables as described in the documentation. 

Example: Routing Claude Code to alternative API endpoints (e.g., claude-code-router) via: `happy --claude-env ANTHROPIC_BASE_URL=http://127.0.0.1:3456`

The env vars flow through the existing claudeEnvVars plumbing to the Claude spawn.