### PR TITLE
fix(claudeLocal): convert --continue to --resume to avoid flag conflict

### DIFF
--- a/src/claude/utils/claudeFindLastSession.ts
+++ b/src/claude/utils/claudeFindLastSession.ts
@@ -1,0 +1,35 @@
+import { readdirSync, statSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getProjectPath } from './path';
+import { claudeCheckSession } from './claudeCheckSession';
+
+/**
+ * Finds the most recently modified VALID session in the project directory.
+ * A valid session must contain at least one message with a uuid field.
+ * Returns the session ID (filename without .jsonl extension) or null if no valid sessions found.
+ */
+export function claudeFindLastSession(workingDirectory: string): string | null {
+    try {
+        const projectDir = getProjectPath(workingDirectory);
+        const files = readdirSync(projectDir)
+            .filter(f => f.endsWith('.jsonl'))
+            .map(f => {
+                const sessionId = f.replace('.jsonl', '');
+                // Check if this is a valid session
+                if (claudeCheckSession(sessionId, workingDirectory)) {
+                    return {
+                        name: f,
+                        sessionId: sessionId,
+                        mtime: statSync(join(projectDir, f)).mtime.getTime()
+                    };
+                }
+                return null;
+            })
+            .filter(f => f !== null)
+            .sort((a, b) => b.mtime - a.mtime); // Most recent valid session first
+
+        return files.length > 0 ? files[0].sessionId : null;
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
Claude Code 2.0.64 rejects --session-id with --continue. Instead of complex flag filtering, simply convert --continue to --resume by finding the last session (which is what --continue does anyway).

This maintains happy-cli's session control while achieving the same behavior as --continue.

- Added claudeFindLastSession() utility to find most recent session
- claudeLocal.ts: Convert --continue to --resume before processing

fix(ClaudeLocal): resolve --continue/--session-id flag conflict in Claude 2.0.64

- Remove buggy validation that checked opts.sessionId instead of startFrom
- Enhance claudeFindLastSession to find most recent VALID session using claudeCheckSession
- If no valid sessions exist, --continue creates a new session instead of failing

Resolves critical bug where "happy --continue" failed with: "Error: --session-id cannot be used with --continue or --resume"

Files modified:
- src/claude/claudeLocal.ts: Remove incorrect validation
- src/claude/utils/claudeFindLastSession.ts: Find most recent valid session