### PR TITLE
fix: use runtime execPath for MCP bridge

### DIFF
--- a/src/codex/runCodex.ts
+++ b/src/codex/runCodex.ts
@@ -536,11 +536,12 @@ export async function runCodex(opts: {
 
     // Start Happy MCP server (HTTP) and prepare STDIO bridge config for Codex
     const happyServer = await startHappyServer(session);
-    const bridgeCommand = join(projectPath(), 'bin', 'happy-mcp.mjs');
+    const bridgeScript = join(projectPath(), 'bin', 'happy-mcp.mjs');
+    // Use process.execPath (bun or node) as command to support both runtimes
     const mcpServers = {
         happy: {
-            command: bridgeCommand,
-            args: ['--url', happyServer.url]
+            command: process.execPath,
+            args: [bridgeScript, '--url', happyServer.url]
         }
     } as const;
     let first = true;

--- a/src/gemini/runGemini.ts
+++ b/src/gemini/runGemini.ts
@@ -421,11 +421,12 @@ export async function runGemini(opts: {
   //
 
   const happyServer = await startHappyServer(session);
-  const bridgeCommand = join(projectPath(), 'bin', 'happy-mcp.mjs');
+  const bridgeScript = join(projectPath(), 'bin', 'happy-mcp.mjs');
+  // Use process.execPath (bun or node) as command to support both runtimes
   const mcpServers = {
     happy: {
-      command: bridgeCommand,
-      args: ['--url', happyServer.url]
+      command: process.execPath,
+      args: [bridgeScript, '--url', happyServer.url]
     }
   };
 


### PR DESCRIPTION
## Summary
Use the active runtime (Node or Bun) to launch the MCP bridge and CLI, improving compatibility when running under Bun or a custom runtime path.

## Changes
- MCP bridge now uses `process.execPath` as the command and passes the bridge script path as the first arg.
- CLI spawn resolves runtime from `HAPPY_NODE_BIN` or `process.execPath`, with Bun detection by version/basename.
- Node-only flags are skipped for Bun, and the resolved runtime is logged for debugging.

## Risk / Notes
- Runtime path falls back to `node` if no execPath is available.
- Bun detection depends on `process.versions.bun` or runtime basename containing `bun`.