### PR TITLE
codex: make abort graceful; force-close MCP on kill/exit

### DIFF
--- a/src/codex/codexMcpClient.ts
+++ b/src/codex/codexMcpClient.ts
@@ -295,6 +295,21 @@ export class CodexMcpClient {
         return this.sessionId;
     }
 
+    /**
+     * Force close the Codex MCP transport and clear all session identifiers.
+     * Use this for permanent shutdown (e.g. kill/exit). Prefer `disconnect()` for
+     * transient connection resets where you may want to keep the session id.
+     */
+    async forceCloseSession(): Promise<void> {
+        logger.debug('[CodexMCP] Force closing session');
+        try {
+            await this.disconnect();
+        } finally {
+            this.clearSession();
+        }
+        logger.debug('[CodexMCP] Session force-closed');
+    }
+
     async disconnect(): Promise<void> {
         if (!this.connected) return;
 
@@ -327,9 +342,7 @@ export class CodexMcpClient {
 
         this.transport = null;
         this.connected = false;
-        this.sessionId = null;
-        this.conversationId = null;
-
-        logger.debug('[CodexMCP] Disconnected');
+        // Preserve session/conversation identifiers for potential reconnection / recovery flows.
+        logger.debug(`[CodexMCP] Disconnected; session ${this.sessionId ?? 'none'} preserved`);
     }
 }

--- a/src/codex/runCodex.ts
+++ b/src/codex/runCodex.ts
@@ -242,10 +242,7 @@ export async function runCodex(opts: {
             }
             
             abortController.abort();
-            messageQueue.reset();
-            permissionHandler.reset();
             reasoningProcessor.abort();
-            diffProcessor.reset();
             logger.debug('[Codex] Abort completed - session remains active');
         } catch (error) {
             logger.debug('[Codex] Error during abort:', error);
@@ -280,6 +277,13 @@ export async function runCodex(opts: {
                 session.sendSessionDeath();
                 await session.flush();
                 await session.close();
+            }
+
+            // Force close Codex transport (best-effort) so we don't leave stray processes
+            try {
+                await client.forceCloseSession();
+            } catch (e) {
+                logger.debug('[Codex] Error while force closing Codex session during termination', e);
             }
 
             // Stop caffeinate
@@ -691,11 +695,9 @@ export async function runCodex(opts: {
                 if (isAbortError) {
                     messageBuffer.addMessage('Aborted by user', 'status');
                     session.sendSessionEvent({ type: 'message', message: 'Aborted by user' });
-                    // Session was already stored in handleAbort(), no need to store again
-                    // Mark session as not created to force proper resume on next message
-                    wasCreated = false;
-                    currentModeHash = null;
-                    logger.debug('[Codex] Marked session as not created after abort for proper resume');
+                    // Abort cancels the current task/inference but keeps the Codex session alive.
+                    // Do not clear session state here; the next user message should continue on the
+                    // existing session if possible.
                 } else {
                     messageBuffer.addMessage('Process exited unexpectedly', 'status');
                     session.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
@@ -738,9 +740,9 @@ export async function runCodex(opts: {
         } catch (e) {
             logger.debug('[codex]: Error while closing session', e);
         }
-        logger.debug('[codex]: client.disconnect begin');
-        await client.disconnect();
-        logger.debug('[codex]: client.disconnect done');
+        logger.debug('[codex]: client.forceCloseSession begin');
+        await client.forceCloseSession();
+        logger.debug('[codex]: client.forceCloseSession done');
         // Stop Happy MCP server
         logger.debug('[codex]: happyServer.stop');
         happyServer.stop();


### PR DESCRIPTION
- **Problem:** Codex “abort” completely killed the current session: it reset internal state and would effectively terminate the session instead of just stopping the current turn. It means that when trying to abort a Codex action, Codex would **lose all context** of the current session.
- **Change:**
  - **Abort** now cancels the in-flight task (`AbortController.abort()` + reasoning abort) **without resetting** message queue / permissions / diff state, so the user can immediately send follow-up instructions and continue the same session.
  - **Kill/exit** uses a hard shutdown path (`forceCloseSession`) so the Codex MCP transport is torn down and session identifiers are cleared, avoiding leaked child processes and leaving no half-alive state.
- **Why:** Aligns Codex behavior with Claude behavior: **abort = stop current work and keep session alive**, **kill = archive session and exit**.