### PR TITLE
ui: surface agent errors in UI (Claude/Codex/Gemini)

### DIFF
--- a/src/claude/claudeLocalLauncher.ts
+++ b/src/claude/claudeLocalLauncher.ts
@@ -3,6 +3,7 @@ import { claudeLocal } from "./claudeLocal";
 import { Session } from "./session";
 import { Future } from "@/utils/future";
 import { createSessionScanner } from "./utils/sessionScanner";
+import { formatErrorForUi } from "@/utils/formatErrorForUi";
 
 export async function claudeLocalLauncher(session: Session): Promise<'switch' | 'exit'> {
 
@@ -123,7 +124,7 @@ export async function claudeLocalLauncher(session: Session): Promise<'switch' | 
             } catch (e) {
                 logger.debug('[local]: launch error', e);
                 if (!exitReason) {
-                    session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
+                    session.client.sendSessionEvent({ type: 'message', message: `Claude process error: ${formatErrorForUi(e)}` });
                     continue;
                 } else {
                     break;

--- a/src/claude/claudeRemoteLauncher.ts
+++ b/src/claude/claudeRemoteLauncher.ts
@@ -15,6 +15,7 @@ import { EnhancedMode } from "./loop";
 import { RawJSONLines } from "@/claude/types";
 import { OutgoingMessageQueue } from "./utils/OutgoingMessageQueue";
 import { getToolName } from "./utils/getToolName";
+import { formatErrorForUi } from "@/utils/formatErrorForUi";
 
 interface PermissionsField {
     date: number;
@@ -402,7 +403,7 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
             } catch (e) {
                 logger.debug('[remote]: launch error', e);
                 if (!exitReason) {
-                    session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
+                    session.client.sendSessionEvent({ type: 'message', message: `Claude process error: ${formatErrorForUi(e)}` });
                     continue;
                 }
             } finally {

--- a/src/gemini/runGemini.ts
+++ b/src/gemini/runGemini.ts
@@ -27,6 +27,7 @@ import { MessageBuffer } from '@/ui/ink/messageBuffer';
 import { notifyDaemonSessionStarted } from '@/daemon/controlClient';
 import { registerKillSessionHandler } from '@/claude/registerKillSessionHandler';
 import { stopCaffeinate } from '@/utils/caffeinate';
+import { formatErrorForUi } from '@/utils/formatErrorForUi';
 
 import { createGeminiBackend } from '@/agent/acp/gemini';
 import type { AgentBackend, AgentMessage } from '@/agent/AgentBackend';
@@ -1039,7 +1040,7 @@ export async function runGemini(opts: {
               errorMsg = errorDetails || errorMessage || errObj.message;
             }
           } else if (error instanceof Error) {
-            errorMsg = error.message;
+            errorMsg = formatErrorForUi(error);
           }
           
           messageBuffer.addMessage(errorMsg, 'status');

--- a/src/utils/formatErrorForUi.ts
+++ b/src/utils/formatErrorForUi.ts
@@ -1,0 +1,14 @@
+/**
+ * Convert an unknown thrown value into a user-visible string.
+ *
+ * Intended for UI surfaces (TUI/mobile) where giant stacks can be noisy; we keep a generous cap.
+ */
+export function formatErrorForUi(error: unknown, opts?: { maxChars?: number }): string {
+    const maxChars = Math.max(1000, opts?.maxChars ?? 50_000);
+    const msg = error instanceof Error
+        ? (error.stack || error.message || String(error))
+        : String(error);
+
+    return msg.length > maxChars ? `${msg.slice(0, maxChars)}\n…[truncated]` : msg;
+}
+


### PR DESCRIPTION
- **Problem:** Several failure modes were only visible in logs, leading to “nothing happened” in the UI.
- **Change:**
  - Add a shared helper `src/utils/formatErrorForUi.ts` for consistent, bounded error formatting.
  - **Claude:** show `Claude process error: <details>` instead of a generic “exited unexpectedly”.
  - **Codex:** surface error conditions directly in UI:
    - streamed MCP `error` events
    - stream errors (`stream_error`)
    - MCP startup failures (`mcp_startup_update` with failed state)
    - tool-call failures when MCP responses return `isError` for both `codex` (start) and `codex-reply` (continue)
  - **Gemini:** keep existing user-friendly error mapping, but improve generic fallback to include formatted error details.
- **Why:** Improves debuggability and user trust by ensuring backend/runtime failures aren’t silently hidden.