### PR TITLE
fix(cli): improve abort error handling to reduce spurious error messages

### DIFF
--- a/src/claude/claudeRemoteLauncher.ts
+++ b/src/claude/claudeRemoteLauncher.ts
@@ -6,7 +6,7 @@ import React from "react";
 import { claudeRemote } from "./claudeRemote";
 import { PermissionHandler } from "./utils/permissionHandler";
 import { Future } from "@/utils/future";
-import { SDKAssistantMessage, SDKMessage, SDKUserMessage } from "./sdk";
+import { AbortError, SDKAssistantMessage, SDKMessage, SDKUserMessage } from "./sdk";
 import { formatClaudeMessageForInk } from "@/ui/messageFormatterInk";
 import { logger } from "@/ui/logger";
 import { SDKToLogConverter } from "./utils/sdkToLogConverter";
@@ -21,6 +21,50 @@ interface PermissionsField {
     result: 'approved' | 'denied';
     mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
     allowedTools?: string[];
+}
+
+type LaunchErrorInfo = {
+    asString: string;
+    name?: string;
+    message?: string;
+    code?: string;
+    stack?: string;
+};
+
+function getLaunchErrorInfo(e: unknown): LaunchErrorInfo {
+    let asString = '[unprintable error]';
+    try {
+        asString = typeof e === 'string' ? e : String(e);
+    } catch {
+        // Ignore
+    }
+
+    if (!e || typeof e !== 'object') {
+        return { asString };
+    }
+
+    const err = e as { name?: unknown; message?: unknown; code?: unknown; stack?: unknown };
+
+    const name = typeof err.name === 'string' ? err.name : undefined;
+    const message = typeof err.message === 'string' ? err.message : undefined;
+    const code = typeof err.code === 'string' || typeof err.code === 'number' ? String(err.code) : undefined;
+    const stack = typeof err.stack === 'string' ? err.stack : undefined;
+
+    return { asString, name, message, code, stack };
+}
+
+function isAbortError(e: unknown): boolean {
+    if (e instanceof AbortError) return true;
+
+    if (!e || typeof e !== 'object') {
+        return false;
+    }
+
+    const err = e as { name?: unknown; code?: unknown };
+    if (typeof err.name === 'string' && err.name === 'AbortError') return true;
+    if (typeof err.code === 'string' && err.code === 'ABORT_ERR') return true;
+
+    return false;
 }
 
 export async function claudeRemoteLauncher(session: Session): Promise<'switch' | 'exit'> {
@@ -400,8 +444,20 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                     session.client.sendSessionEvent({ type: 'message', message: 'Aborted by user' });
                 }
             } catch (e) {
-                logger.debug('[remote]: launch error', e);
+                const abortError = isAbortError(e);
+                logger.debug('[remote]: launch error', {
+                    ...getLaunchErrorInfo(e),
+                    abortError,
+                });
+
                 if (!exitReason) {
+                    if (abortError) {
+                        if (controller.signal.aborted) {
+                            session.client.sendSessionEvent({ type: 'message', message: 'Aborted by user' });
+                        }
+                        continue;
+                    }
+
                     session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
                     continue;
                 }


### PR DESCRIPTION
## Summary

- Detect DOMException/AbortError from Node.js spawn (which appears as `{}` when logged due to non-enumerable properties)
- Only show "Process exited unexpectedly" for genuine failures, not transient abort/retry situations
- Better error logging with `getLaunchErrorInfo()` that extracts error.name, error.message, error.code for debugging

## Problem

When users send messages from the mobile app after the session is in "ready" state, occasionally the spawn throws a DOMException (from Node.js AbortSignal) that appears as `{}` when logged. The session actually recovers on retry, but users see a confusing "Process exited unexpectedly" error message.

## Changes

- Added `LaunchErrorInfo` type and `getLaunchErrorInfo()` helper to properly extract error details from any error type
- Added `isAbortError()` helper to detect both SDK `AbortError` class and Node.js native DOMException/AbortError
- Modified catch block to skip "Process exited unexpectedly" message for abort-related errors during retry cycles

## Test plan

- [x] Build passes (`yarn build`)
- [x] Tests pass (`yarn test`)
- [ ] Manual testing with mobile app during abort/retry scenarios

---

🤖 Generated with [Claude Code](https://claude.ai/code) + [Codex](https://openai.com/codex)

Co-Authored-By: Codex <noreply@openai.com>