### PR TITLE
fix: handle spaces and underscores in project paths

### DIFF
--- a/src/claude/utils/path.ts
+++ b/src/claude/utils/path.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
 export function getProjectPath(workingDirectory: string) {
-    const projectId = resolve(workingDirectory).replace(/[\\\/\.:]/g, '-');
+    const projectId = resolve(workingDirectory).replace(/[\\\/\.: _]/g, '-');
     const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
     return join(claudeConfigDir, 'projects', projectId);
 }


### PR DESCRIPTION
## Summary
  - Fix project path generation to handle directories with spaces and underscores
  - Added ` ` (space) and `_` (underscore) to the character replacement regex in
  `getProjectPath()`

  ## Problem
  Directories with spaces or underscores in their names could cause issues with Claude
  session file paths.

  ## Solution
  Extended the regex from `/[\\\/\.:]/g` to `/[\\\/\.: _]/g` to replace these characters
  with hyphens.