### PR TITLE
fix: forward signals to child process in binary launcher

### DIFF
--- a/scripts/claude_version_utils.cjs
+++ b/scripts/claude_version_utils.cjs
@@ -497,6 +497,18 @@ function runClaudeCli(cliPath) {
             stdio: 'inherit',
             env: process.env
         });
+
+        // Forward signals to child process so it gets killed when parent is killed
+        // This prevents orphaned Claude processes when switching between local/remote modes
+        const forwardSignal = (signal) => {
+            if (child.pid && !child.killed) {
+                child.kill(signal);
+            }
+        };
+        process.on('SIGTERM', () => forwardSignal('SIGTERM'));
+        process.on('SIGINT', () => forwardSignal('SIGINT'));
+        process.on('SIGHUP', () => forwardSignal('SIGHUP'));
+
         child.on('exit', (code) => {
             process.exit(code || 0);
         });


### PR DESCRIPTION
Cleans up remote process when switching back to local mode, avoiding two processes competing for the input/output. Fixes  slopus/happy#430