### PR TITLE
fix: set permissionMode when --yolo flag is used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -491,6 +491,8 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
       } else if (arg === '--yolo') {
         // Shortcut for --dangerously-skip-permissions
         unknownArgs.push('--dangerously-skip-permissions')
+        // Also set internal permissionMode for PermissionHandler (fixes #206)
+        options.permissionMode = 'bypassPermissions'
       } else if (arg === '--started-by') {
         options.startedBy = args[++i] as 'daemon' | 'terminal'
       } else if (arg === '--js-runtime') {


### PR DESCRIPTION
## Summary

Fixes #206 - 'yolo' mode not sticking in happy app

This PR contains two related fixes:

### Fix 1: Set `options.permissionMode` when `--yolo` flag is used

The `--yolo` flag only passed `--dangerously-skip-permissions` to Claude CLI but did not set `options.permissionMode` internally. This caused the `PermissionHandler` to stay in "default" mode.

```typescript
// Before: only passes CLI flag to Claude
} else if (arg === '--yolo') {
  unknownArgs.push('--dangerously-skip-permissions')
}

// After: ALSO sets internal permissionMode
} else if (arg === '--yolo') {
  unknownArgs.push('--dangerously-skip-permissions')
  options.permissionMode = 'bypassPermissions'
}
```

### Fix 2: Preserve CLI permission mode when mobile sends "default"

When the CLI is started with `--yolo`, messages from the mobile app with `permissionMode: "default"` would override the CLI's setting. Now the CLI's explicit mode is preserved unless the mobile explicitly chooses a different mode.

```typescript
// If CLI was started with --yolo, don't let "default" messages override it
if (cliPermissionMode && incomingMode === 'default') {
    messagePermissionMode = cliPermissionMode;
}
```

## Test Plan

- [x] Built and installed CLI locally from v0.13.0 + fix
- [x] Started `happy --yolo`
- [x] Verified "bypass permissions on" shows in status bar
- [x] Sent command from mobile app (with default permission mode)
- [x] Confirmed tool executes without permission prompt
- [x] Session runs successfully

## Notes

- Based on v0.13.0 tag for testing, but PR targets main
- The fix applies cleanly to both v0.13.0 and current main
- Previous attempt in PR #86 tried a more complex solution

## Related

- Closes #206