### PR TITLE
fix: move claudeArgs to end of args array for slash command support

### DIFF
--- a/src/claude/claudeLocal.ts
+++ b/src/claude/claudeLocal.ts
@@ -199,15 +199,15 @@ export async function claudeLocal(opts: {
                 args.push('--allowedTools', opts.allowedTools.join(','));
             }
 
-            // Add custom Claude arguments
-            if (opts.claudeArgs) {
-                args.push(...opts.claudeArgs)
-            }
-
             // Add hook settings for session tracking (when available)
             if (opts.hookSettingsPath) {
                 args.push('--settings', opts.hookSettingsPath);
                 logger.debug(`[ClaudeLocal] Using hook settings: ${opts.hookSettingsPath}`);
+            }
+
+            // Add custom Claude arguments LAST (so prompt/slash commands are at the end)
+            if (opts.claudeArgs) {
+                args.push(...opts.claudeArgs)
             }
 
             if (!claudeCliPath || !existsSync(claudeCliPath)) {


### PR DESCRIPTION
## Problem

Running `happy /help` or any slash command didn't work. Commands weren't being interpreted by Claude.

## Root Cause

Claude CLI expects: `claude [options] [prompt]` — the prompt must come **last**.

Happy was building args like this:
```
claude --append-system-prompt "..." /help --settings "..."
```

The `/help` was placed **before** `--settings`, so Claude didn't recognize it as the prompt.

## Fix

Moved `claudeArgs` to be added **after** all flags:
```
claude --append-system-prompt "..." --settings "..." /help
```

Now `/help` is at the end, Claude parses it as the prompt, and interprets `/` as a slash command.

## Changes

- `src/claude/claudeLocal.ts` — reordered when `claudeArgs` gets pushed to the args array (6 lines moved, no logic change)

## Testing

```bash
happy /help
happy /compact
happy /doctor
```