### PR TITLE
feat: add session resume support via RPC

### DIFF
--- a/src/api/apiMachine.ts
+++ b/src/api/apiMachine.ts
@@ -102,14 +102,14 @@ export class ApiMachineClient {
     }: MachineRpcHandlers) {
         // Register spawn session handler
         this.rpcHandlerManager.registerHandler('spawn-happy-session', async (params: any) => {
-            const { directory, sessionId, machineId, approvedNewDirectoryCreation, agent, token, environmentVariables } = params || {};
+            const { directory, sessionId, machineId, approvedNewDirectoryCreation, agent, token, environmentVariables, resumeClaudeSessionId } = params || {};
             logger.debug(`[API MACHINE] Spawning session with params: ${JSON.stringify(params)}`);
 
             if (!directory) {
                 throw new Error('Directory is required');
             }
 
-            const result = await spawnSession({ directory, sessionId, machineId, approvedNewDirectoryCreation, agent, token, environmentVariables });
+            const result = await spawnSession({ directory, sessionId, machineId, approvedNewDirectoryCreation, agent, token, environmentVariables, resumeClaudeSessionId });
 
             switch (result.type) {
                 case 'success':

--- a/src/modules/common/registerCommonHandlers.ts
+++ b/src/modules/common/registerCommonHandlers.ts
@@ -122,6 +122,7 @@ export interface SpawnSessionOptions {
     approvedNewDirectoryCreation?: boolean;
     agent?: 'claude' | 'codex' | 'gemini';
     token?: string;
+    resumeClaudeSessionId?: string;  // Claude Code session ID to resume with --resume flag
     environmentVariables?: {
         // Anthropic Claude API configuration
         ANTHROPIC_BASE_URL?: string;        // Custom API endpoint (overrides default)


### PR DESCRIPTION
## Summary
- Add `resumeClaudeSessionId` parameter to `spawn-happy-session` RPC call
- When provided, daemon passes `--resume <sessionId>` flag to Claude Code
- Enables session resume from mobile app or other clients

## Changes
- `src/modules/common/registerCommonHandlers.ts`: Add `resumeClaudeSessionId` to `SpawnSessionOptions` interface
- `src/daemon/run.ts`: Pass `--resume` flag in both regular and tmux spawn modes  
- `src/api/apiMachine.ts`: Extract and forward `resumeClaudeSessionId` in RPC handler

## Use Case
This enables the "Resume Session" feature in Happy mobile app for offline/stopped sessions. Users can now restore previous Claude Code sessions from the UI instead of losing context.

## Testing
- [ ] Regular spawn with resume
- [ ] Tmux spawn with resume
- [ ] Spawn without resume (backward compatible)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)