### PR TITLE
feat: Add model parameter to spawn session options

### DIFF
--- a/src/api/apiMachine.ts
+++ b/src/api/apiMachine.ts
@@ -102,14 +102,14 @@ export class ApiMachineClient {
     }: MachineRpcHandlers) {
         // Register spawn session handler
         this.rpcHandlerManager.registerHandler('spawn-happy-session', async (params: any) => {
-            const { directory, sessionId, machineId, approvedNewDirectoryCreation, agent, token, environmentVariables } = params || {};
+            const { directory, sessionId, machineId, approvedNewDirectoryCreation, agent, token, model, environmentVariables } = params || {};
             logger.debug(`[API MACHINE] Spawning session with params: ${JSON.stringify(params)}`);
 
             if (!directory) {
                 throw new Error('Directory is required');
             }
 
-            const result = await spawnSession({ directory, sessionId, machineId, approvedNewDirectoryCreation, agent, token, environmentVariables });
+            const result = await spawnSession({ directory, sessionId, machineId, approvedNewDirectoryCreation, agent, token, model, environmentVariables });
 
             switch (result.type) {
                 case 'success':

--- a/src/modules/common/registerCommonHandlers.ts
+++ b/src/modules/common/registerCommonHandlers.ts
@@ -122,6 +122,8 @@ export interface SpawnSessionOptions {
     approvedNewDirectoryCreation?: boolean;
     agent?: 'claude' | 'codex' | 'gemini';
     token?: string;
+    /** Model alias (e.g., 'sonnet', 'opus') or full name. Takes precedence over environmentVariables.ANTHROPIC_MODEL */
+    model?: string;
     environmentVariables?: {
         // Anthropic Claude API configuration
         ANTHROPIC_BASE_URL?: string;        // Custom API endpoint (overrides default)


### PR DESCRIPTION
## Summary

Allows mobile app to specify model (e.g., 'sonnet', 'opus') when spawning sessions.

**Changes:**
- Add `model` field to `SpawnSessionOptions` interface
- Extract `model` from `spawn-happy-session` RPC params  
- Set `ANTHROPIC_MODEL` env var from model option (takes precedence over profile)
- Pass `--model` flag to Claude CLI when spawning (both regular and tmux modes)

## Problem

When selecting a model in the Happy Coder mobile app before spawning a session, the model selection was ignored. Sessions always started with the default model (Opus 4.5) regardless of user selection.

**Evidence from daemon logs:**
```
[API MACHINE] Spawning session with params: {"type":"spawn-in-directory","directory":"...","agent":"claude"}
```
No `model` field was being passed or used.

## Solution

This PR adds support for a `model` field in the spawn session options. When the mobile app sends `model: "sonnet"`, the daemon will:
1. Set `ANTHROPIC_MODEL=sonnet` in the spawned process environment
2. Pass `--model sonnet` flag to the Claude CLI

The fix is backward compatible - if mobile doesn't send `model`, behavior is unchanged.

## Files Changed

- `src/modules/common/registerCommonHandlers.ts` - Add `model` to interface
- `src/api/apiMachine.ts` - Extract and pass `model` from RPC params
- `src/daemon/run.ts` - Use `model` in env and CLI args

## Testing

- [ ] Spawn session from mobile with model selection
- [ ] Verify daemon logs show model being set
- [ ] Verify Claude uses the correct model

## Note for Mobile App

The mobile app (slopus/happy) needs to be updated to send `model` in the spawn params:
```json
{
  "type": "spawn-in-directory",
  "directory": "/path/to/dir",
  "agent": "claude",
  "model": "sonnet"
}
```

Fixes #158

---
Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>