### PR TITLE
feat: add theme system with dark/light mode support

### DIFF
--- a/src/claude/runClaude.ts
+++ b/src/claude/runClaude.ts
@@ -13,6 +13,7 @@ import { hashObject } from '@/utils/deterministicJson';
 import { startCaffeinate, stopCaffeinate } from '@/utils/caffeinate';
 import { extractSDKMetadataAsync } from '@/claude/sdk/metadataExtractor';
 import { parseSpecialCommand } from '@/parsers/specialCommands';
+import { initTheme } from '@/ui/theme';
 import { getEnvironmentInfo } from '@/ui/doctor';
 import { configuration } from '@/configuration';
 import { notifyDaemonSessionStarted } from '@/daemon/controlClient';
@@ -70,6 +71,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
 
     // Get machine ID from settings (should already be set up)
     const settings = await readSettings();
+    initTheme(settings.theme);
     let machineId = settings?.machineId
     if (!machineId) {
         console.error(`[START] No machine ID found in settings, which is unexpected since authAndSetupMachineIfNeeded should have created it. Please report this issue on https://github.com/slopus/happy-cli/issues`);

--- a/src/codex/runCodex.ts
+++ b/src/codex/runCodex.ts
@@ -13,6 +13,7 @@ import { configuration } from '@/configuration';
 import packageJson from '../../package.json';
 import os from 'node:os';
 import { MessageQueue2 } from '@/utils/MessageQueue2';
+import { initTheme } from '@/ui/theme';
 import { hashObject } from '@/utils/deterministicJson';
 import { projectPath } from '@/projectPath';
 import { resolve, join } from 'node:path';
@@ -93,6 +94,7 @@ export async function runCodex(opts: {
     //
 
     const settings = await readSettings();
+    initTheme(settings.theme);
     let machineId = settings?.machineId;
     if (!machineId) {
         console.error(`[START] No machine ID found in settings, which is unexpected since authAndSetupMachineIfNeeded should have created it. Please report this issue on https://github.com/slopus/happy-cli/issues`);

--- a/src/gemini/runGemini.ts
+++ b/src/gemini/runGemini.ts
@@ -20,6 +20,7 @@ import { initialMachineMetadata } from '@/daemon/run';
 import { configuration } from '@/configuration';
 import packageJson from '../../package.json';
 import { MessageQueue2 } from '@/utils/MessageQueue2';
+import { initTheme } from '@/ui/theme';
 import { hashObject } from '@/utils/deterministicJson';
 import { projectPath } from '@/projectPath';
 import { startHappyServer } from '@/claude/utils/startHappyServer';
@@ -78,6 +79,7 @@ export async function runGemini(opts: {
   //
 
   const settings = await readSettings();
+  initTheme(settings.theme);
   const machineId = settings?.machineId;
   if (!machineId) {
     console.error(`[START] No machine ID found in settings, which is unexpected since authAndSetupMachineIfNeeded should have created it. Please report this issue on https://github.com/slopus/happy-cli/issues`);

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -12,6 +12,7 @@ import { configuration } from '@/configuration'
 import * as z from 'zod';
 import { encodeBase64 } from '@/api/encryption';
 import { logger } from '@/ui/logger';
+import type { ThemeName } from '@/ui/theme';
 
 // AI backend profile schema - MUST match happy app exactly
 // Using same Zod schema as GUI for runtime validation consistency
@@ -208,6 +209,8 @@ interface Settings {
   profiles: AIBackendProfile[]
   // CLI-local environment variable cache (not synced)
   localEnvironmentVariables: Record<string, Record<string, string>> // profileId -> env vars
+  // UI theme for terminal display ('dark' | 'light')
+  theme?: ThemeName
 }
 
 const defaultSettings: Settings = {

--- a/src/ui/ink/CodexDisplay.tsx
+++ b/src/ui/ink/CodexDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { Box, Text, useStdout, useInput } from 'ink'
 import { MessageBuffer, type BufferedMessage } from './messageBuffer'
+import { getTheme } from '@/ui/theme'
 
 interface CodexDisplayProps {
     messageBuffer: MessageBuffer
@@ -76,17 +77,7 @@ export const CodexDisplay: React.FC<CodexDisplayProps> = ({ messageBuffer, logPa
         }
     }, [confirmationMode, actionInProgress, onExit, setConfirmationWithTimeout, resetConfirmation]))
 
-    const getMessageColor = (type: BufferedMessage['type']): string => {
-        switch (type) {
-            case 'user': return 'magenta'
-            case 'assistant': return 'cyan'
-            case 'system': return 'blue'
-            case 'tool': return 'yellow'
-            case 'result': return 'green'
-            case 'status': return 'gray'
-            default: return 'white'
-        }
-    }
+    const theme = getTheme()
 
     const formatMessage = (msg: BufferedMessage): string => {
         const lines = msg.content.split('\n')
@@ -109,23 +100,23 @@ export const CodexDisplay: React.FC<CodexDisplayProps> = ({ messageBuffer, logPa
                 width={terminalWidth}
                 height={terminalHeight - 4}
                 borderStyle="round"
-                borderColor="gray"
+                borderColor={theme.colors.border}
                 paddingX={1}
                 overflow="hidden"
             >
                 <Box flexDirection="column" marginBottom={1}>
-                    <Text color="gray" bold>🤖 Codex Agent Messages</Text>
-                    <Text color="gray" dimColor>{'─'.repeat(Math.min(terminalWidth - 4, 60))}</Text>
+                    <Text color={theme.colors.header} bold>🤖 Codex Agent Messages</Text>
+                    <Text color={theme.colors.separator} dimColor={theme.dimMessages}>{'─'.repeat(Math.min(terminalWidth - 4, 60))}</Text>
                 </Box>
-                
+
                 <Box flexDirection="column" height={terminalHeight - 10} overflow="hidden">
                     {messages.length === 0 ? (
-                        <Text color="gray" dimColor>Waiting for messages...</Text>
+                        <Text color={theme.colors.muted} dimColor={theme.dimMessages}>Waiting for messages...</Text>
                     ) : (
                         // Show only the last messages that fit in the available space
                         messages.slice(-Math.max(1, terminalHeight - 10)).map((msg) => (
                             <Box key={msg.id} flexDirection="column" marginBottom={1}>
-                                <Text color={getMessageColor(msg.type)} dimColor>
+                                <Text color={theme.colors.message(msg.type)} dimColor={theme.dimMessages}>
                                     {formatMessage(msg)}
                                 </Text>
                             </Box>
@@ -139,8 +130,8 @@ export const CodexDisplay: React.FC<CodexDisplayProps> = ({ messageBuffer, logPa
                 width={terminalWidth}
                 borderStyle="round"
                 borderColor={
-                    actionInProgress ? "gray" :
-                    confirmationMode ? "red" : 
+                    actionInProgress ? theme.colors.muted :
+                    confirmationMode ? "red" :
                     "green"
                 }
                 paddingX={2}
@@ -150,7 +141,7 @@ export const CodexDisplay: React.FC<CodexDisplayProps> = ({ messageBuffer, logPa
             >
                 <Box flexDirection="column" alignItems="center">
                     {actionInProgress ? (
-                        <Text color="gray" bold>
+                        <Text color={theme.colors.muted} bold>
                             Exiting agent...
                         </Text>
                     ) : confirmationMode ? (
@@ -165,7 +156,7 @@ export const CodexDisplay: React.FC<CodexDisplayProps> = ({ messageBuffer, logPa
                         </>
                     )}
                     {process.env.DEBUG && logPath && (
-                        <Text color="gray" dimColor>
+                        <Text color={theme.colors.muted} dimColor={theme.dimMessages}>
                             Debug logs: {logPath}
                         </Text>
                     )}

--- a/src/ui/ink/GeminiDisplay.tsx
+++ b/src/ui/ink/GeminiDisplay.tsx
@@ -8,6 +8,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Box, Text, useStdout, useInput } from 'ink';
 import { MessageBuffer, type BufferedMessage } from './messageBuffer';
+import { getTheme } from '@/ui/theme';
 
 interface GeminiDisplayProps {
   messageBuffer: MessageBuffer;
@@ -110,17 +111,7 @@ export const GeminiDisplay: React.FC<GeminiDisplayProps> = ({ messageBuffer, log
     }
   }, [confirmationMode, actionInProgress, onExit, setConfirmationWithTimeout, resetConfirmation]));
 
-  const getMessageColor = (type: BufferedMessage['type']): string => {
-    switch (type) {
-      case 'user': return 'magenta';
-      case 'assistant': return 'cyan';
-      case 'system': return 'blue';
-      case 'tool': return 'yellow';
-      case 'result': return 'green';
-      case 'status': return 'gray';
-      default: return 'white';
-    }
-  };
+  const theme = getTheme();
 
   const formatMessage = (msg: BufferedMessage): string => {
     const lines = msg.content.split('\n');
@@ -143,18 +134,18 @@ export const GeminiDisplay: React.FC<GeminiDisplayProps> = ({ messageBuffer, log
         width={terminalWidth}
         height={terminalHeight - 4}
         borderStyle="round"
-        borderColor="gray"
+        borderColor={theme.colors.border}
         paddingX={1}
         overflow="hidden"
       >
         <Box flexDirection="column" marginBottom={1}>
           <Text color="cyan" bold>✨ Gemini Agent Messages</Text>
-          <Text color="gray" dimColor>{'─'.repeat(Math.min(terminalWidth - 4, 60))}</Text>
+          <Text color={theme.colors.separator} dimColor={theme.dimMessages}>{'─'.repeat(Math.min(terminalWidth - 4, 60))}</Text>
         </Box>
 
         <Box flexDirection="column" height={terminalHeight - 10} overflow="hidden">
           {messages.length === 0 ? (
-            <Text color="gray" dimColor>Waiting for messages...</Text>
+            <Text color={theme.colors.muted} dimColor={theme.dimMessages}>Waiting for messages...</Text>
           ) : (
             messages
               .filter(msg => {
@@ -177,7 +168,7 @@ export const GeminiDisplay: React.FC<GeminiDisplayProps> = ({ messageBuffer, log
               .slice(-Math.max(1, terminalHeight - 10))
               .map((msg, index, array) => (
                 <Box key={msg.id} flexDirection="column" marginBottom={index < array.length - 1 ? 1 : 0}>
-                  <Text color={getMessageColor(msg.type)} dimColor>
+                  <Text color={theme.colors.message(msg.type)} dimColor={theme.dimMessages}>
                     {formatMessage(msg)}
                   </Text>
                 </Box>
@@ -191,7 +182,7 @@ export const GeminiDisplay: React.FC<GeminiDisplayProps> = ({ messageBuffer, log
         width={terminalWidth}
         borderStyle="round"
         borderColor={
-          actionInProgress ? 'gray' :
+          actionInProgress ? theme.colors.muted :
           confirmationMode ? 'red' :
           'cyan'
         }
@@ -202,7 +193,7 @@ export const GeminiDisplay: React.FC<GeminiDisplayProps> = ({ messageBuffer, log
       >
         <Box flexDirection="column" alignItems="center">
           {actionInProgress ? (
-            <Text color="gray" bold>
+            <Text color={theme.colors.muted} bold>
               Exiting agent...
             </Text>
           ) : confirmationMode ? (
@@ -215,14 +206,14 @@ export const GeminiDisplay: React.FC<GeminiDisplayProps> = ({ messageBuffer, log
                 ✨ Gemini Agent Running • Ctrl-C to exit
               </Text>
               {model && (
-                <Text color="gray" dimColor>
+                <Text color={theme.colors.muted} dimColor={theme.dimMessages}>
                   Model: {model}
                 </Text>
               )}
             </>
           )}
           {process.env.DEBUG && logPath && (
-            <Text color="gray" dimColor>
+            <Text color={theme.colors.muted} dimColor={theme.dimMessages}>
               Debug logs: {logPath}
             </Text>
           )}

--- a/src/ui/ink/RemoteModeDisplay.tsx
+++ b/src/ui/ink/RemoteModeDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { Box, Text, useStdout, useInput } from 'ink'
 import { MessageBuffer, type BufferedMessage } from './messageBuffer'
+import { getTheme } from '@/ui/theme'
 
 interface RemoteModeDisplayProps {
     messageBuffer: MessageBuffer
@@ -93,17 +94,7 @@ export const RemoteModeDisplay: React.FC<RemoteModeDisplayProps> = ({ messageBuf
         }
     }, [confirmationMode, actionInProgress, onExit, onSwitchToLocal, setConfirmationWithTimeout, resetConfirmation]))
 
-    const getMessageColor = (type: BufferedMessage['type']): string => {
-        switch (type) {
-            case 'user': return 'magenta'
-            case 'assistant': return 'cyan'
-            case 'system': return 'blue'
-            case 'tool': return 'yellow'
-            case 'result': return 'green'
-            case 'status': return 'gray'
-            default: return 'white'
-        }
-    }
+    const theme = getTheme()
 
     const formatMessage = (msg: BufferedMessage): string => {
         const lines = msg.content.split('\n')
@@ -126,23 +117,23 @@ export const RemoteModeDisplay: React.FC<RemoteModeDisplayProps> = ({ messageBuf
                 width={terminalWidth}
                 height={terminalHeight - 4}
                 borderStyle="round"
-                borderColor="gray"
+                borderColor={theme.colors.border}
                 paddingX={1}
                 overflow="hidden"
             >
                 <Box flexDirection="column" marginBottom={1}>
-                    <Text color="gray" bold>📡 Remote Mode - Claude Messages</Text>
-                    <Text color="gray" dimColor>{'─'.repeat(Math.min(terminalWidth - 4, 60))}</Text>
+                    <Text color={theme.colors.header} bold>📡 Remote Mode - Claude Messages</Text>
+                    <Text color={theme.colors.separator} dimColor={theme.dimMessages}>{'─'.repeat(Math.min(terminalWidth - 4, 60))}</Text>
                 </Box>
-                
+
                 <Box flexDirection="column" height={terminalHeight - 10} overflow="hidden">
                     {messages.length === 0 ? (
-                        <Text color="gray" dimColor>Waiting for messages...</Text>
+                        <Text color={theme.colors.muted} dimColor={theme.dimMessages}>Waiting for messages...</Text>
                     ) : (
                         // Show only the last messages that fit in the available space
                         messages.slice(-Math.max(1, terminalHeight - 10)).map((msg) => (
                             <Box key={msg.id} flexDirection="column" marginBottom={1}>
-                                <Text color={getMessageColor(msg.type)} dimColor>
+                                <Text color={theme.colors.message(msg.type)} dimColor={theme.dimMessages}>
                                     {formatMessage(msg)}
                                 </Text>
                             </Box>
@@ -156,9 +147,9 @@ export const RemoteModeDisplay: React.FC<RemoteModeDisplayProps> = ({ messageBuf
                 width={terminalWidth}
                 borderStyle="round"
                 borderColor={
-                    actionInProgress ? "gray" :
-                    confirmationMode === 'exit' ? "red" : 
-                    confirmationMode === 'switch' ? "yellow" : 
+                    actionInProgress ? theme.colors.muted :
+                    confirmationMode === 'exit' ? "red" :
+                    confirmationMode === 'switch' ? "yellow" :
                     "green"
                 }
                 paddingX={2}
@@ -168,11 +159,11 @@ export const RemoteModeDisplay: React.FC<RemoteModeDisplayProps> = ({ messageBuf
             >
                 <Box flexDirection="column" alignItems="center">
                     {actionInProgress === 'exiting' ? (
-                        <Text color="gray" bold>
+                        <Text color={theme.colors.muted} bold>
                             Exiting...
                         </Text>
                     ) : actionInProgress === 'switching' ? (
-                        <Text color="gray" bold>
+                        <Text color={theme.colors.muted} bold>
                             Switching to local mode...
                         </Text>
                     ) : confirmationMode === 'exit' ? (
@@ -191,7 +182,7 @@ export const RemoteModeDisplay: React.FC<RemoteModeDisplayProps> = ({ messageBuf
                         </>
                     )}
                     {process.env.DEBUG && logPath && (
-                        <Text color="gray" dimColor>
+                        <Text color={theme.colors.muted} dimColor={theme.dimMessages}>
                             Debug logs: {logPath}
                         </Text>
                     )}

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,0 +1,124 @@
+/**
+ * Theme system for happy-cli terminal display
+ *
+ * Centralizes color definitions for Ink display components.
+ * Supports dark (default) and light themes for different terminal backgrounds.
+ *
+ * Configuration priority:
+ *   1. HAPPY_THEME env var ('dark' | 'light')
+ *   2. settings.json theme field
+ *   3. Default: 'dark'
+ */
+
+import type { BufferedMessage } from '@/ui/ink/messageBuffer'
+
+export type ThemeName = 'dark' | 'light'
+
+type MessageType = BufferedMessage['type']
+
+export interface ThemeColors {
+    /** Color for each message type */
+    message: (type: MessageType) => string
+    /** Border color for Box components */
+    border: string
+    /** Header/title text color */
+    header: string
+    /** Separator line color */
+    separator: string
+    /** Muted text color (debug info, paths) */
+    muted: string
+}
+
+export interface Theme {
+    name: ThemeName
+    colors: ThemeColors
+    /** Whether to apply dimColor prop to message text */
+    dimMessages: boolean
+}
+
+function darkMessageColor(type: MessageType): string {
+    switch (type) {
+        case 'user': return 'magenta'
+        case 'assistant': return 'cyan'
+        case 'system': return 'blue'
+        case 'tool': return 'yellow'
+        case 'result': return 'green'
+        case 'status': return 'gray'
+        default: return 'white'
+    }
+}
+
+function lightMessageColor(type: MessageType): string {
+    switch (type) {
+        case 'user': return '#9b006e'
+        case 'assistant': return '#006688'
+        case 'system': return '#0044aa'
+        case 'tool': return '#886600'
+        case 'result': return '#006622'
+        case 'status': return '#555555'
+        default: return '#333333'
+    }
+}
+
+const darkTheme: Theme = {
+    name: 'dark',
+    colors: {
+        message: darkMessageColor,
+        border: 'gray',
+        header: 'gray',
+        separator: 'gray',
+        muted: 'gray',
+    },
+    dimMessages: true,
+}
+
+const lightTheme: Theme = {
+    name: 'light',
+    colors: {
+        message: lightMessageColor,
+        border: '#888888',
+        header: '#555555',
+        separator: '#999999',
+        muted: '#777777',
+    },
+    dimMessages: false,
+}
+
+const themes: Record<ThemeName, Theme> = {
+    dark: darkTheme,
+    light: lightTheme,
+}
+
+function resolveThemeFromEnv(): ThemeName | undefined {
+    const envValue = process.env.HAPPY_THEME?.toLowerCase()
+    if (envValue === 'dark' || envValue === 'light') {
+        return envValue
+    }
+    return undefined
+}
+
+let cachedTheme: Theme | undefined
+
+/**
+ * Get the current theme. Returns cached instance after first call.
+ *
+ * Resolution priority:
+ *   1. HAPPY_THEME env var
+ *   2. Value passed to initTheme() from settings.json
+ *   3. Default: 'dark'
+ */
+export function getTheme(): Theme {
+    if (cachedTheme) return cachedTheme
+    cachedTheme = themes[resolveThemeFromEnv() ?? 'dark']
+    return cachedTheme
+}
+
+/**
+ * Initialize theme with settings.json value.
+ * Call once at app startup after reading settings.
+ * Env var always takes priority over settings value.
+ */
+export function initTheme(settingsTheme?: ThemeName): void {
+    const envTheme = resolveThemeFromEnv()
+    cachedTheme = themes[envTheme ?? settingsTheme ?? 'dark']
+}


### PR DESCRIPTION
Add a shared theme module to centralize color definitions for Ink display components. The light theme uses high-contrast colors readable on white terminal backgrounds, fixing the readability issue in remote mode.

Changes:
- Add src/ui/theme.ts with dark/light theme palettes
- Add theme field to settings.json schema
- Refactor RemoteModeDisplay, CodexDisplay, GeminiDisplay to use shared theme
- Remove duplicated getMessageColor() from 3 components
- Make dimColor theme-controlled (off for light theme)

Configure via HAPPY_THEME=light env var or settings.json theme field.

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)