### PR TITLE
fix: correct argument ordering for Claude CLI prompts and commands

### DIFF
--- a/src/claude/claudeLocal.ts
+++ b/src/claude/claudeLocal.ts
@@ -199,15 +199,18 @@ export async function claudeLocal(opts: {
                 args.push('--allowedTools', opts.allowedTools.join(','));
             }
 
-            // Add custom Claude arguments
-            if (opts.claudeArgs) {
-                args.push(...opts.claudeArgs)
-            }
-
             // Add hook settings for session tracking (when available)
+            // IMPORTANT: This must come BEFORE claudeArgs so that positional arguments
+            // (like prompts) in claudeArgs are placed at the end
             if (opts.hookSettingsPath) {
                 args.push('--settings', opts.hookSettingsPath);
                 logger.debug(`[ClaudeLocal] Using hook settings: ${opts.hookSettingsPath}`);
+            }
+
+            // Add custom Claude arguments
+            // These go LAST so positional arguments (prompts) are at the end
+            if (opts.claudeArgs) {
+                args.push(...opts.claudeArgs)
             }
 
             if (!claudeCliPath || !existsSync(claudeCliPath)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -513,6 +513,15 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
           console.error(chalk.red(`Invalid --claude-env format: ${envArg}. Expected KEY=VALUE`))
           process.exit(1)
         }
+      } else if (arg === '--claude-arg') {
+        // Pass specific argument to Claude CLI
+        if (i + 1 >= args.length) {
+          console.error(chalk.red(`Missing value for --claude-arg`))
+          process.exit(1)
+        }
+        const claudeArg = args[++i]
+        options.claudeArgs = options.claudeArgs || []
+        options.claudeArgs.push(claudeArg)
       } else {
         // Pass unknown arguments through to claude
         unknownArgs.push(arg)


### PR DESCRIPTION
- Implement --claude-arg flag (was documented in README but not implemented)
- Move --settings flag before claudeArgs to ensure positional arguments come last
- Fixes issue where prompts and slash commands were ignored

The bug occurred because claudeArgs were inserted between flags, but Claude CLI expects positional arguments at the end: claude [flags] [prompt]

Changes:
- src/index.ts: Added --claude-arg flag parsing
- src/claude/claudeLocal.ts: Reordered args to put --settings before claudeArgs