### PR TITLE
fix(sdk): strip CLAUDECODE env var when spawning Claude Code

### DIFF
--- a/src/claude/sdk/query.ts
+++ b/src/claude/sdk/query.ts
@@ -340,7 +340,10 @@ export function query(config: {
 
     // Spawn Claude Code process
     // Use clean env for global claude to avoid local node_modules/.bin taking precedence
-    const spawnEnv = isCommandOnly ? getCleanEnv() : process.env
+    // Always strip CLAUDECODE env var to prevent nested-session detection (Claude Code 2.1+)
+    const baseEnv = isCommandOnly ? getCleanEnv() : { ...process.env }
+    delete baseEnv.CLAUDECODE
+    const spawnEnv = baseEnv
     logDebug(`Spawning Claude Code process: ${spawnCommand} ${spawnArgs.join(' ')} (using ${isCommandOnly ? 'clean' : 'normal'} env)`)
 
     const child = spawn(spawnCommand, spawnArgs, {


### PR DESCRIPTION
## Summary

- Claude Code 2.1+ sets a `CLAUDECODE` environment variable and blocks launch if it's already present (nested-session detection)
- happy-cli passes `process.env` unchanged to the child Claude Code process, causing it to immediately exit with code 1
- Every remote session crashes on first message and retries 3 times before giving up
- Fix: strip `CLAUDECODE` from the child process environment before spawning

## Root Cause

Claude Code 2.1.41 introduced nested-session detection that checks for the `CLAUDECODE` env var. Since happy-cli is itself launched by Claude Code (or inherits the env), the spawned child process sees this variable and refuses to start:

```
Error: Claude Code cannot be launched inside another Claude Code session.
Nested sessions share runtime resources and will crash all active sessions.
To bypass this check, unset the CLAUDECODE environment variable.
```

The `getCleanEnv()` path (used for command-only mode) already strips problematic env vars, but the normal spawn path passes `process.env` directly.

## Changes

`src/claude/sdk/query.ts`: Always delete `CLAUDECODE` from the child process environment, regardless of spawn mode.

## Test plan

- [ ] Start daemon, send message from mobile app — session should start without crashing
- [ ] Verify `claude --version` still works (command-only mode uses `getCleanEnv()`)
- [ ] Verify interactive mode still works

🤖 Generated with [Claude Code](https://claude.ai/code)